### PR TITLE
B35_2465826

### DIFF
--- a/zstl/test/org/zkoss/zktest/test2/B35/B35_2465826Test.scala
+++ b/zstl/test/org/zkoss/zktest/test2/B35/B35_2465826Test.scala
@@ -76,18 +76,32 @@ class B35_2465826Test extends ZTL4ScalaTestCase {
 
       // Record the selected item text
       val itemText = jq(".z-listitem-seld").text();
-      
+
       // Press enter key
-      sendKeys(jq(".z-listcell-cnt").get(0).toElement(), Keys.ENTER);
-      
+      sendKeys(jq(".z-listcell-cnt").toElement(), Keys.ENTER);
+      waitResponse();
+
       // Verify that the messagebox is visible
       verifyTrue("The Messagebox should be visible", jq(".z-messagebox-window").exists());
-      
+
       // Press enter key again
-      sendKeys(jq(".z-button").get(0).toElement(), Keys.ENTER);
+      sendKeys(jq(".z-window-highlighted-cnt").toElement(), Keys.ENTER);
+      waitResponse();
 
       // Verify that the selected item is the same as before
-      verifyTrue("The selected item changed", itemText.equals(jq(".z-listitem-seld")));
+      verifyTrue("The selected item changed", itemText.equals(jq(".z-listitem-seld").text()));
+
+      // Press down key
+      sendKeys(jq(".z-listcell-cnt").toElement(), Keys.DOWN);
+      waitResponse();
+
+      // Press up key
+      sendKeys(jq(".z-listcell-cnt").toElement(), Keys.UP);
+      waitResponse();
+
+      // Verify that the selected item is the same as before
+      verifyTrue("The selected item changed", itemText.equals(jq(".z-listitem-seld").text()));
+
     })
   }
 }


### PR DESCRIPTION
In Chrome the first enter hit doesn't work.

```
   org.openqa.selenium.WebDriverException: Failed to send keys because cannot focus element. (WARNING: 
```

In Firefox the second one doesn't work.

```
   org.openqa.selenium.StaleElementReferenceException: Element is no longer attached to the DOM
```

I probed to hit the sendkeys event on many targets, but had no lucky.
