### PR TITLE
Update ztl.ignore

### DIFF
--- a/ztl.ignore
+++ b/ztl.ignore
@@ -315,7 +315,8 @@ Z60-B00775ListmodelSelection.ztl
 }
 opera,chrome,safari,firefox*={
 B65-ZK-1642.ztl
-B65-ZK-1215.ztl 
+B65-ZK-1215.ztl
+B65-ZK-1748.ztl 
 }
 // ie10 only
 opera,chrome,safari,firefox*,ie6,ie7,ie8,ie9={


### PR DESCRIPTION
- [x] B65-ZK-1748 (IE only)
- [x] B65-ZK-1769 (IE 10 only)
